### PR TITLE
Add support for setup in  GPC transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ framework:
 
 * `OrderingKeyStamp`: use for keeping messages of the same context in order. 
   For more information, read an [official documentation](https://cloud.google.com/pubsub/docs/publisher#using_ordering_keys). 
+
+### Step 5: Create topics from config
+```bash
+bin/console messenger:setup-transports
+```

--- a/Tests/Transport/GpsTransportFactoryTest.php
+++ b/Tests/Transport/GpsTransportFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetitPress\GpsMessengerBundle\Tests\Transport;
+
+use PetitPress\GpsMessengerBundle\Transport\GpsConfigurationResolverInterface;
+use PetitPress\GpsMessengerBundle\Transport\GpsTransportFactory;
+use PHPUnit\Framework\TestCase;
+
+class GpsTransportFactoryTest extends TestCase
+{
+    private GpsTransportFactory $subject;
+    private GpsConfigurationResolverInterface $gpsConfigurationResolver;
+
+    protected function setUp(): void
+    {
+        $this->gpsConfigurationResolver = $this->createMock(GpsConfigurationResolverInterface::class);
+
+        $this->subject = new GpsTransportFactory($this->gpsConfigurationResolver);
+    }
+
+    /**
+     * @dataProvider dsnProvider
+     */
+    public function testSupports(bool $expected, string $dsn): void
+    {
+        $this->assertSame($expected, $this->subject->supports($dsn, []));
+    }
+
+    public function dsnProvider(): array
+    {
+        return [
+            [true,  'gps://defaults/messages?client_config[apiEndpoint]=0.0.0.0:8432'],
+            [false, 'http://0.0.0.0:8080'],
+            [false, 'https://0.0.0.0:8080'],
+            [false, '0.0.0.0:8080'],
+        ];
+    }
+}

--- a/Tests/Transport/GpsTransportTest.php
+++ b/Tests/Transport/GpsTransportTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetitPress\GpsMessengerBundle\Tests\Transport;
+
+use Generator;
+use Google\Cloud\PubSub\Message;
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\Subscription;
+use Google\Cloud\PubSub\Topic;
+use PetitPress\GpsMessengerBundle\Transport\GpsConfigurationInterface;
+use PetitPress\GpsMessengerBundle\Transport\GpsReceiver;
+use PetitPress\GpsMessengerBundle\Transport\GpsSender;
+use PetitPress\GpsMessengerBundle\Transport\GpsTransport;
+use PetitPress\GpsMessengerBundle\Transport\Stamp\GpsReceivedStamp;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+class GpsTransportTest extends TestCase
+{
+    private GpsTransport $subject;
+    private PubSubClient $pubSubClient;
+    private GpsConfigurationInterface $gpsConfiguration;
+
+    /**
+     * @var SerializerInterface|MockObject
+     */
+    private $serializerMock;
+
+    protected function setUp(): void
+    {
+        $this->pubSubClient = $this->createMock(PubSubClient::class);
+        $this->gpsConfiguration = $this->createMock(GpsConfigurationInterface::class);
+        $this->serializerMock = $this->createMock(SerializerInterface::class);
+
+        $this->subject = new GpsTransport(
+            $this->pubSubClient,
+            $this->gpsConfiguration,
+            $this->serializerMock
+        );
+    }
+
+    public function testGet(): void
+    {
+        $this->assertInstanceOf(Generator::class, $this->subject->get());
+    }
+
+    public function testAck(): void
+    {
+        $this->expectException(TransportException::class);
+        $this->expectErrorMessage('No GpsReceivedStamp found on the Envelope.');
+
+        $this->subject->ack(new Envelope(new stdClass()));
+    }
+
+    public function testReject(): void
+    {
+        $this->expectException(TransportException::class);
+        $this->expectErrorMessage('No GpsReceivedStamp found on the Envelope.');
+
+        $this->subject->reject(new Envelope(new stdClass()));
+    }
+
+    public function testSend(): void
+    {
+        $transportConfiguration = new GpsReceivedStamp(
+            new Message([
+                'data' => '{}',
+                'messageId' => 'messageId',
+                'publishTime' => time(),
+                'attributes' => [],
+                'orderingKey' => null
+            ])
+        );
+
+        $message = new stdClass();
+        $message->prop = 'test';
+
+        $envelope = new Envelope(new stdClass(), [$transportConfiguration]);
+
+        $this->serializerMock
+            ->expects($this->once())
+            ->method('encode')
+            ->willReturn([
+                'body' => '{}',
+                'headers' => []
+            ]);
+
+        $topicMock = $this->createMock(Topic::class);
+        $topicMock
+            ->expects($this->once())
+            ->method('publish');
+
+        $this->pubSubClient
+            ->expects($this->once())
+            ->method('topic')
+            ->willReturn($topicMock);
+
+        $finalEnvelop = $this->subject->send($envelope);
+
+        $this->assertInstanceOf(Envelope::class, $finalEnvelop);
+    }
+
+    public function testSetup()
+    {
+        $queue = 'test';
+
+        $this->gpsConfiguration
+            ->expects($this->atLeast(2))
+            ->method('getQueueName')
+            ->willReturn($queue);
+
+        $this->gpsConfiguration
+            ->expects($this->atLeast(2))
+            ->method('getSubscriptionName')
+            ->willReturn($queue);
+
+        $topicMock = $this->createMock(Topic::class);
+        $topicMock
+            ->expects($this->once())
+            ->method('exists')
+            ->willReturn(false);
+
+
+        $subscriptionMock = $this->createMock(Subscription::class);
+        $subscriptionMock
+            ->expects($this->once())
+            ->method('exists')
+            ->willReturn(false);
+
+        $topicMock
+            ->expects($this->once())
+            ->method('subscription')
+            ->willReturn($subscriptionMock);
+
+        $this->pubSubClient
+            ->expects($this->once())
+            ->method('topic')
+            ->willReturn($topicMock);
+
+        $this->pubSubClient
+            ->expects($this->once())
+            ->method('createTopic')
+            ->willReturn($topicMock);
+
+        $this->subject->setup();
+    }
+
+    public function testGetReceiver()
+    {
+        $this->assertInstanceOf(GpsReceiver::class, $this->subject->getReceiver());
+    }
+
+    public function testGetSender()
+    {
+        $this->assertInstanceOf(GpsSender::class, $this->subject->getSender());
+    }
+}

--- a/Tests/Transport/GpsTransportTest.php
+++ b/Tests/Transport/GpsTransportTest.php
@@ -23,9 +23,20 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class GpsTransportTest extends TestCase
 {
-    private GpsTransport $subject;
-    private PubSubClient $pubSubClient;
-    private GpsConfigurationInterface $gpsConfiguration;
+    /**
+     * @var GpsTransport|MockObject
+     */
+    private $subject;
+
+    /**
+     * @var PubSubClient|MockObject
+     */
+    private $pubSubClient;
+    
+    /**
+     * @var GpsConfigurationInterface|MockObject
+     */
+    private $gpsConfiguration;
 
     /**
      * @var SerializerInterface|MockObject
@@ -69,27 +80,31 @@ class GpsTransportTest extends TestCase
     public function testSend(): void
     {
         $transportConfiguration = new GpsReceivedStamp(
-            new Message([
-                'data' => '{}',
-                'messageId' => 'messageId',
-                'publishTime' => time(),
-                'attributes' => [],
-                'orderingKey' => null
-            ])
+            new Message(
+                [
+                    'data' => '{}',
+                    'messageId' => 'messageId',
+                    'publishTime' => time(),
+                    'attributes' => [],
+                    'orderingKey' => null,
+                ]
+            )
         );
 
         $message = new stdClass();
         $message->prop = 'test';
 
-        $envelope = new Envelope(new stdClass(), [$transportConfiguration]);
+        $envelope = new Envelope($message, [$transportConfiguration]);
 
         $this->serializerMock
             ->expects($this->once())
             ->method('encode')
-            ->willReturn([
-                'body' => '{}',
-                'headers' => []
-            ]);
+            ->willReturn(
+                [
+                    'body' => '{}',
+                    'headers' => [],
+                ]
+            );
 
         $topicMock = $this->createMock(Topic::class);
         $topicMock
@@ -125,7 +140,6 @@ class GpsTransportTest extends TestCase
             ->expects($this->once())
             ->method('exists')
             ->willReturn(false);
-
 
         $subscriptionMock = $this->createMock(Subscription::class);
         $subscriptionMock


### PR DESCRIPTION
# Allow GPC topic be created by Symfony 

## Development impact
1. Extended `GpsTransport` with implementing `SetupableTransportInterface` Symfony interface.
2. Added new method `GpsTransport::setup`
3. Added UnitTest for new method
4. Added test for `GpsTransportFactory::support` to validate correct transport attachment. 
<img width="523" alt="Снимок экрана 2022-07-27 в 11 55 52" src="https://user-images.githubusercontent.com/2750628/181226404-c9f530aa-ea58-45f5-8bd9-6117be9a1943.png">


## Steps to reproduce 
1. Go to the project inside the terminal 
6. Run `bin/console messenger:setup-transports`
7. You will see the message: `! [NOTE] The "{queueName}" transport does not support setup. `   

## Acceptance criteria
1. Go to the project inside the terminal 
2. Run `bin/console messenger:setup-transports`
3. You will see the message: `[OK] The "{queueName}" transport was set up successfully. `   

## Steps for test
1. Create GPS emulator pub/sub
2. Setup new queue by DSN with value: `gps://defaults/{queueName}?client_config[apiEndpoint]=http://{emulatorHost}:{emulatorPort}&max_messages_pull=10`
2.1 {queueName} - future queue name
2.2. {emulatorHost} - host of emulator (default: localhost)
2.3 {emulatorPort} - port of emulator (default: 8432)
3. Add a new queue to config for `packages/messenger.yml`
```YAML
# config/packages/messenger.yaml

framework:
    messenger:
        transports:
        transports:
            messages:
                dsn: 'gps://defaults/messages?client_config[apiEndpoint]=http://localhost:8432&max_messages_pull=10`'
```
8. Go to project terminal and run: `bin/console messenger:setup-transports`
9. Should see the message: `[OK] The "messages" transport was set up successfully. `


