### PR TITLE
feat: add an AttibutesStamp to handle serialized message attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ petit_press_gps_messenger:
 ### Step 5: Use available stamps if needed
 
 * `OrderingKeyStamp`: use for keeping messages of the same context in order. 
-  For more information, read an [official documentation](https://cloud.google.com/pubsub/docs/publisher#using_ordering_keys). 
+  For more information, read an [official documentation](https://cloud.google.com/pubsub/docs/publisher#using_ordering_keys).
+
+* `AttributesStamp`: use to add contextual metadata to serialized messages. 
+  For more information, read an [official documentation](https://cloud.google.com/pubsub/docs/publisher#using-attributes). 
+  Can be very useful when used together with [subscription filters](https://cloud.google.com/pubsub/docs/subscription-message-filter).
 
 ### Step 6: Create topics from config
 ```bash

--- a/Transport/GpsSender.php
+++ b/Transport/GpsSender.php
@@ -6,6 +6,7 @@ namespace PetitPress\GpsMessengerBundle\Transport;
 
 use Google\Cloud\PubSub\MessageBuilder;
 use Google\Cloud\PubSub\PubSubClient;
+use PetitPress\GpsMessengerBundle\Transport\Stamp\AttributesStamp;
 use PetitPress\GpsMessengerBundle\Transport\Stamp\OrderingKeyStamp;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -55,6 +56,11 @@ final class GpsSender implements SenderInterface
         $orderingKeyStamp = $envelope->last(OrderingKeyStamp::class);
         if ($orderingKeyStamp instanceof OrderingKeyStamp) {
             $messageBuilder = $messageBuilder->setOrderingKey($orderingKeyStamp->getOrderingKey());
+        }
+
+        $attributesStamp = $envelope->last(AttributesStamp::class);
+        if ($attributesStamp instanceof AttributesStamp) {
+            $messageBuilder = $messageBuilder->setAttributes($attributesStamp->getAttributes());
         }
 
         $this->pubSubClient

--- a/Transport/Stamp/AttributesStamp.php
+++ b/Transport/Stamp/AttributesStamp.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetitPress\GpsMessengerBundle\Transport\Stamp;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+final class AttributesStamp implements NonSendableStampInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $attributes;
+
+    /**
+     * @param array<string, string> $attributes
+     */
+    public function __construct(array $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+}


### PR DESCRIPTION
As stated in the README, it comes very handy when combined with subscription filters (also the use case we currently need).

I did not add the stamp back in the receiver since there is already a `GpsReceivedStamp` which allows to do:
```php
$stamp = $envelope->last(GpsReceivedStamp::class);
if ($stamp instanceof GpsReceivedStamp) {
    $attributes = $stamp->getMessage()->attributes();

    // do something with attributes
}
```