### PR TITLE
feat: allow to configure options when calling pull method on subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ framework:
                 options:
                     client_config: # optional (default: [])
                         apiEndpoint: 'https://europe-west3-pubsub.googleapis.com'
-                    max_messages_pull: 10 # optional (default: 10)
                     topic: # optional (default name: messages)
                         name: 'messages'
                         options: # optional create options if not exists (default: []), for all options take at look at https://googleapis.github.io/google-cloud-php/#/docs/google-cloud/v0.188.0/pubsub/topic?method=create
@@ -66,6 +65,9 @@ framework:
                             labels:
                                 - label1
                                 - label2
+                        pull:
+                            maxMessages: 10 # optional (default: 10)
+
 ```
 or:
 ```yaml
@@ -75,7 +77,7 @@ framework:
     messenger:
         transports:
             gps_transport:
-                dsn: 'gps://default/messages?client_config[apiEndpoint]=https://europe-west3-pubsub.googleapis.com&max_messages_pull=10'
+                dsn: 'gps://default/messages?client_config[apiEndpoint]=https://europe-west3-pubsub.googleapis.com&subscription[pull][maxMessages]=10'
 ```
 to use emulator in local:
 ```yaml

--- a/Tests/Transport/GpsConfigurationTest.php
+++ b/Tests/Transport/GpsConfigurationTest.php
@@ -40,10 +40,10 @@ final class GpsConfigurationTest extends TestCase
                 'expectedConfiguration' => new GpsConfiguration(
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
-                    GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL,
                     [],
                     [],
-                    []
+                    [],
+                    ['maxMessages' => GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL, 'returnImmediately' => false]
                 ),
             ],
             'Custom topic/subscription name configured through dsn #1' => [
@@ -52,10 +52,10 @@ final class GpsConfigurationTest extends TestCase
                 'expectedConfiguration' => new GpsConfiguration(
                     'something',
                     'something',
-                    GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL,
                     [],
                     [],
-                    []
+                    [],
+                    ['maxMessages' => GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL, 'returnImmediately' => false]
                 ),
             ],
             'Custom topic/subscription name configured through dsn #2 (deprecated queue[name])' => [
@@ -64,10 +64,10 @@ final class GpsConfigurationTest extends TestCase
                 'expectedConfiguration' => new GpsConfiguration(
                     'topic_name',
                     'subscription_name',
-                    GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL,
                     [],
                     [],
-                    []
+                    [],
+                    ['maxMessages' => GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL, 'returnImmediately' => false]
                 ),
             ],
             'Custom topic/subscription name configured through dsn #3' => [
@@ -76,10 +76,10 @@ final class GpsConfigurationTest extends TestCase
                 'expectedConfiguration' => new GpsConfiguration(
                     'topic_name',
                     'subscription_name',
-                    5,
                     ['apiEndpoint' => 'https://europe-west3-pubsub.googleapis.com'],
                     ['labels' => ['label_topic1']],
                     ['labels' => ['label_subscription1'], 'enableMessageOrdering' => true, 'ackDeadlineSeconds' => 100],
+                    ['maxMessages' => 5, 'returnImmediately' => false]
                 ),
             ],
             'Custom topic/subscription name configured through options #1' => [
@@ -90,10 +90,10 @@ final class GpsConfigurationTest extends TestCase
                 'expectedConfiguration' => new GpsConfiguration(
                     'something',
                     'something',
-                    GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL,
                     [],
                     [],
-                    []
+                    [],
+                    ['maxMessages' => GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL, 'returnImmediately' => false]
                 ),
             ],
             'Custom topic/subscription name configured through options #2' => [
@@ -105,10 +105,10 @@ final class GpsConfigurationTest extends TestCase
                 'expectedConfiguration' => new GpsConfiguration(
                     'topic_name',
                     'subscription_name',
-                    GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL,
                     [],
                     [],
-                    []
+                    [],
+                    ['maxMessages' => GpsConfigurationResolverInterface::DEFAULT_MAX_MESSAGES_PULL, 'returnImmediately' => false]
                 ),
             ],
             'Custom topic/subscription name configured through options #4' => [
@@ -136,10 +136,72 @@ final class GpsConfigurationTest extends TestCase
                 'expectedConfiguration' => new GpsConfiguration(
                     'topic_name1',
                     'subscription_name',
-                    5,
                     ['apiEndpoint' => 'https://europe-west3-pubsub.googleapis.com'],
                     ['labels' => ['label_topic1']],
                     ['labels' => ['label_subscription1'], 'enableMessageOrdering' => true, 'ackDeadlineSeconds' => 100],
+                    ['maxMessages' => 5, 'returnImmediately' => false]
+                ),
+            ],
+            'Custom subscription pull options configured through dsn #1 (deprecated max_messages_pull)' => [
+                'dsn' => 'gps://default?max_messages_pull=5',
+                'options' => [],
+                'expectedConfiguration' => new GpsConfiguration(
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    [],
+                    [],
+                    [],
+                    ['maxMessages' => 5, 'returnImmediately' => false]
+                ),
+            ],
+            'Custom subscription pull options configured through dsn #2' => [
+                'dsn' => 'gps://default?subscription[pull][maxMessages]=5',
+                'options' => [],
+                'expectedConfiguration' => new GpsConfiguration(
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    [],
+                    [],
+                    [],
+                    ['maxMessages' => 5, 'returnImmediately' => false]
+                ),
+            ],
+            'Custom subscription pull options configured through options #1' => [
+                'dsn' => 'gps://default',
+                'options' => [
+                    'subscription' => [
+                        'pull' => [
+                            'maxMessages' => 5,
+                            'returnImmediately' => true,
+                        ]
+                    ],
+                ],
+                'expectedConfiguration' => new GpsConfiguration(
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    [],
+                    [],
+                    [],
+                    ['maxMessages' => 5, 'returnImmediately' => true]
+                ),
+            ],
+            'Custom subscription pull options configured through options #2' => [
+                'dsn' => 'gps://default',
+                'options' => [
+                    'max_messages_pull' => 5,
+                    'subscription' => [
+                        'pull' => [
+                            'returnImmediately' => true,
+                        ]
+                    ],
+                ],
+                'expectedConfiguration' => new GpsConfiguration(
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    [],
+                    [],
+                    [],
+                    ['maxMessages' => 5, 'returnImmediately' => true]
                 ),
             ],
         ];

--- a/Transport/GpsConfiguration.php
+++ b/Transport/GpsConfiguration.php
@@ -11,25 +11,25 @@ final class GpsConfiguration implements GpsConfigurationInterface
 {
     private string $topicName;
     private string $subscriptionName;
-    private int $maxMessagesPull;
     private array $clientConfig;
     private array $topicOptions;
     private array $subscriptionOptions;
+    private array $subscriptionPullOptions;
 
     public function __construct(
         string $queueName,
         string $subscriptionName,
-        int $maxMessagesPull,
         array $clientConfig,
         array $topicOptions,
-        array $subscriptionOptions
+        array $subscriptionOptions,
+        array $subscriptionPullOptions
     ) {
         $this->topicName = $queueName;
         $this->subscriptionName = $subscriptionName;
-        $this->maxMessagesPull = $maxMessagesPull;
         $this->clientConfig = $clientConfig;
         $this->topicOptions = $topicOptions;
         $this->subscriptionOptions = $subscriptionOptions;
+        $this->subscriptionPullOptions = $subscriptionPullOptions;
     }
 
     public function getTopicName(): string
@@ -40,11 +40,6 @@ final class GpsConfiguration implements GpsConfigurationInterface
     public function getSubscriptionName(): string
     {
         return $this->subscriptionName;
-    }
-
-    public function getMaxMessagesPull(): int
-    {
-        return $this->maxMessagesPull;
     }
 
     public function getClientConfig(): array
@@ -60,5 +55,10 @@ final class GpsConfiguration implements GpsConfigurationInterface
     public function getSubscriptionOptions(): array
     {
         return $this->subscriptionOptions;
+    }
+
+    public function getSubscriptionPullOptions(): array
+    {
+        return $this->subscriptionPullOptions;
     }
 }

--- a/Transport/GpsConfigurationInterface.php
+++ b/Transport/GpsConfigurationInterface.php
@@ -17,8 +17,6 @@ interface GpsConfigurationInterface
 
     public function getSubscriptionName(): string;
 
-    public function getMaxMessagesPull(): int;
-
     /**
      * @see PubSubClient constructor options
      */
@@ -33,4 +31,9 @@ interface GpsConfigurationInterface
      * @see Subscription::create options
      */
     public function getSubscriptionOptions(): array;
+
+    /**
+     * @see Subscription::pull options
+     */
+    public function getSubscriptionPullOptions(): array;
 }

--- a/Transport/GpsReceiver.php
+++ b/Transport/GpsReceiver.php
@@ -45,7 +45,7 @@ final class GpsReceiver implements ReceiverInterface
         try {
             $messages = $this->pubSubClient
                 ->subscription($this->gpsConfiguration->getSubscriptionName())
-                ->pull(['maxMessages' => $this->gpsConfiguration->getMaxMessagesPull()]);
+                ->pull($this->gpsConfiguration->getSubscriptionPullOptions());
 
             foreach ($messages as $message) {
                 yield $this->createEnvelopeFromPubSubMessage($message);


### PR DESCRIPTION
When [processing batch messages](https://symfony.com/doc/6.3/messenger.html#process-messages-by-batches), it's more efficient to use `returnImmediately: true` to let the worker flush the pending message when it enters idle mode.

Without `returnImmediately: true`, PubSub client will wait until a message is send and the BatchHandler will have to reach the `batchSize` limit before processing its messages

To fix this behavior, I propose to allow configuring `maxMessages` and `returnImmediately` options under `subscription.pull` key