### PR TITLE
Remove mandatory topic subscription creation

### DIFF
--- a/Tests/Transport/GpsConfigurationTest.php
+++ b/Tests/Transport/GpsConfigurationTest.php
@@ -39,7 +39,9 @@ final class GpsConfigurationTest extends TestCase
                 'options' => [],
                 'expectedConfiguration' => new GpsConfiguration(
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],
@@ -51,7 +53,9 @@ final class GpsConfigurationTest extends TestCase
                 'options' => [],
                 'expectedConfiguration' => new GpsConfiguration(
                     'something',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     'something',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],
@@ -63,7 +67,9 @@ final class GpsConfigurationTest extends TestCase
                 'options' => [],
                 'expectedConfiguration' => new GpsConfiguration(
                     'topic_name',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     'subscription_name',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],
@@ -75,7 +81,9 @@ final class GpsConfigurationTest extends TestCase
                 'options' => [],
                 'expectedConfiguration' => new GpsConfiguration(
                     'topic_name',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     'subscription_name',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     ['apiEndpoint' => 'https://europe-west3-pubsub.googleapis.com'],
                     ['labels' => ['label_topic1']],
                     ['labels' => ['label_subscription1'], 'enableMessageOrdering' => true, 'ackDeadlineSeconds' => 100],
@@ -89,7 +97,9 @@ final class GpsConfigurationTest extends TestCase
                 ],
                 'expectedConfiguration' => new GpsConfiguration(
                     'something',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     'something',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],
@@ -104,7 +114,9 @@ final class GpsConfigurationTest extends TestCase
                 ],
                 'expectedConfiguration' => new GpsConfiguration(
                     'topic_name',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     'subscription_name',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],
@@ -135,7 +147,9 @@ final class GpsConfigurationTest extends TestCase
                 ],
                 'expectedConfiguration' => new GpsConfiguration(
                     'topic_name1',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     'subscription_name',
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     ['apiEndpoint' => 'https://europe-west3-pubsub.googleapis.com'],
                     ['labels' => ['label_topic1']],
                     ['labels' => ['label_subscription1'], 'enableMessageOrdering' => true, 'ackDeadlineSeconds' => 100],
@@ -147,7 +161,9 @@ final class GpsConfigurationTest extends TestCase
                 'options' => [],
                 'expectedConfiguration' => new GpsConfiguration(
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],
@@ -159,7 +175,9 @@ final class GpsConfigurationTest extends TestCase
                 'options' => [],
                 'expectedConfiguration' => new GpsConfiguration(
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],
@@ -178,7 +196,9 @@ final class GpsConfigurationTest extends TestCase
                 ],
                 'expectedConfiguration' => new GpsConfiguration(
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],
@@ -197,7 +217,37 @@ final class GpsConfigurationTest extends TestCase
                 ],
                 'expectedConfiguration' => new GpsConfiguration(
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
+                    [],
+                    [],
+                    [],
+                    ['maxMessages' => 5, 'returnImmediately' => true]
+                ),
+            ],
+            'Subscription is not created' => [
+                'dsn' => 'gps://default',
+                'enableCreation' => false,
+                'expectedConfiguration' => new GpsConfiguration(
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    false,
+                    [],
+                    [],
+                    [],
+                    ['maxMessages' => 5, 'returnImmediately' => true]
+                ),
+            ],
+            'Topic is not created' => [
+                'dsn' => 'gps://default',
+                'enableCreation' => false,
+                'expectedConfiguration' => new GpsConfiguration(
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    false,
+                    GpsConfigurationResolverInterface::DEFAULT_TOPIC_NAME,
+                    GpsConfigurationResolverInterface::CREATION_ENABLE,
                     [],
                     [],
                     [],

--- a/Transport/GpsConfiguration.php
+++ b/Transport/GpsConfiguration.php
@@ -10,22 +10,28 @@ namespace PetitPress\GpsMessengerBundle\Transport;
 final class GpsConfiguration implements GpsConfigurationInterface
 {
     private string $topicName;
+    private bool   $isTopicEnabled;
     private string $subscriptionName;
-    private array $clientConfig;
-    private array $topicOptions;
-    private array $subscriptionOptions;
-    private array $subscriptionPullOptions;
+    private bool   $isSubscriptionEnabled;
+    private array  $clientConfig;
+    private array  $topicOptions;
+    private array  $subscriptionOptions;
+    private array  $subscriptionPullOptions;
 
     public function __construct(
         string $queueName,
+        bool   $isTopicEnabled,
         string $subscriptionName,
-        array $clientConfig,
-        array $topicOptions,
-        array $subscriptionOptions,
-        array $subscriptionPullOptions
+        bool   $isSubscriptionEnabled,
+        array  $clientConfig,
+        array  $topicOptions,
+        array  $subscriptionOptions,
+        array  $subscriptionPullOptions
     ) {
         $this->topicName = $queueName;
+        $this->isTopicEnabled = $isTopicEnabled;
         $this->subscriptionName = $subscriptionName;
+        $this->isSubscriptionEnabled = $isSubscriptionEnabled;
         $this->clientConfig = $clientConfig;
         $this->topicOptions = $topicOptions;
         $this->subscriptionOptions = $subscriptionOptions;
@@ -37,9 +43,19 @@ final class GpsConfiguration implements GpsConfigurationInterface
         return $this->topicName;
     }
 
+    public function isTopicEnabled(): bool
+    {
+        return $this->isTopicEnabled;
+    }
+
     public function getSubscriptionName(): string
     {
         return $this->subscriptionName;
+    }
+
+    public function isSubscriptionEnabled(): bool
+    {
+        return $this->isSubscriptionEnabled;
     }
 
     public function getClientConfig(): array

--- a/Transport/GpsConfigurationInterface.php
+++ b/Transport/GpsConfigurationInterface.php
@@ -15,7 +15,11 @@ interface GpsConfigurationInterface
 {
     public function getTopicName(): string;
 
+    public function isTopicEnabled(): bool;
+
     public function getSubscriptionName(): string;
+
+    public function isSubscriptionEnabled(): bool;
 
     /**
      * @see PubSubClient constructor options

--- a/Transport/GpsConfigurationResolver.php
+++ b/Transport/GpsConfigurationResolver.php
@@ -16,7 +16,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
     private const BOOL_NORMALIZER_KEY = 'bool';
     private const NORMALIZABLE_SUBSCRIPTION_OPTIONS = [
         self::INT_NORMALIZER_KEY => ['ackDeadlineSeconds', 'maxDeliveryAttempts'],
-        self::BOOL_NORMALIZER_KEY => ['enableMessageOrdering', 'retainAckedMessages', 'enableExactlyOnceDelivery', "enableCreation"],
+        self::BOOL_NORMALIZER_KEY => ['enableMessageOrdering', 'retainAckedMessages', 'enableExactlyOnceDelivery', 'enableCreation'],
     ];
     private const NORMALIZABLE_SUBSCRIPTION_PULL_OPTIONS = [
         self::INT_NORMALIZER_KEY => ['maxMessages'],

--- a/Transport/GpsConfigurationResolver.php
+++ b/Transport/GpsConfigurationResolver.php
@@ -16,11 +16,11 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
     private const BOOL_NORMALIZER_KEY = 'bool';
     private const NORMALIZABLE_SUBSCRIPTION_OPTIONS = [
         self::INT_NORMALIZER_KEY => ['ackDeadlineSeconds', 'maxDeliveryAttempts'],
-        self::BOOL_NORMALIZER_KEY => ['enableMessageOrdering', 'retainAckedMessages', 'enableExactlyOnceDelivery'],
+        self::BOOL_NORMALIZER_KEY => ['enableMessageOrdering', 'retainAckedMessages', 'enableExactlyOnceDelivery', "enableCreation"],
     ];
     private const NORMALIZABLE_SUBSCRIPTION_PULL_OPTIONS = [
         self::INT_NORMALIZER_KEY => ['maxMessages'],
-        self::BOOL_NORMALIZER_KEY => ['returnImmediately'],
+        self::BOOL_NORMALIZER_KEY => ['returnImmediately', 'enableCreation'],
     ];
 
     /**
@@ -108,7 +108,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             ->setDefault('topic', function (OptionsResolver $topicResolver): void {
                 $topicResolver
                     ->setDefault('name', self::DEFAULT_TOPIC_NAME)
-                    ->setDefault('options', [])
+                    ->setDefault('enableCreation', true)
                     ->setAllowedTypes('name', 'string')
                     ->setAllowedTypes('options', 'array')
                 ;
@@ -140,7 +140,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
 
                     $resolver
                         ->setDefault('name', $parentOptions['topic']['name'])
-                        ->setDefault('options', [])
+                        ->setDefault('enableCreation', true)
                         ->setDefault(
                             'pull',
                             function (OptionsResolver $pullResolver) use ($parentOptions): void {

--- a/Transport/GpsConfigurationResolverInterface.php
+++ b/Transport/GpsConfigurationResolverInterface.php
@@ -8,6 +8,7 @@ interface GpsConfigurationResolverInterface
 {
     public const DEFAULT_TOPIC_NAME = 'messages';
     public const DEFAULT_MAX_MESSAGES_PULL = 10;
+    public const CREATION_ENABLE = true;
 
     public function resolve(string $dsn, array $options): GpsConfigurationInterface;
 }

--- a/Transport/GpsTransport.php
+++ b/Transport/GpsTransport.php
@@ -91,7 +91,7 @@ final class GpsTransport implements TransportInterface, SetupableTransportInterf
     {
         $topic = $this->pubSubClient->topic($this->gpsConfiguration->getTopicName());
 
-        if (false === $topic->exists()) {
+        if (false === $topic->exists() && $this->gpsConfiguration->isTopicEnabled()) {
             $topic = $this->pubSubClient->createTopic(
                 $this->gpsConfiguration->getTopicName(),
                 $this->gpsConfiguration->getTopicOptions()
@@ -100,7 +100,7 @@ final class GpsTransport implements TransportInterface, SetupableTransportInterf
 
         $subscription = $topic->subscription($this->gpsConfiguration->getSubscriptionName());
 
-        if (false === $subscription->exists()) {
+        if (false === $subscription->exists() && $this->gpsConfiguration->isSubscriptionEnabled()) {
             $topic->subscribe(
                 $this->gpsConfiguration->getSubscriptionName(),
                 $this->gpsConfiguration->getSubscriptionOptions()


### PR DESCRIPTION
The aim is to give the choice of topic creation and subscription independently.

Use case:
- I only want to receive messages from pub/sub and process them with Messenger but not send any myself. In this case, I only need a subscription.
- In the opposite case, I only want to send messages via Messenger but not receive any (in any case from pub/sub).

Another problem with the current implementation is that it requires broad rights on Google. For example, if my service account only has Publisher rights and not Subscriber rights, we're blocked.