### PR TITLE
Fix DI Extension class deprecation

### DIFF
--- a/src/DependencyInjection/PetitPressGpsMessengerExtension.php
+++ b/src/DependencyInjection/PetitPressGpsMessengerExtension.php
@@ -7,9 +7,9 @@ namespace PetitPress\GpsMessengerBundle\DependencyInjection;
 use PetitPress\GpsMessengerBundle\Transport\GpsTransportFactory;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 final class PetitPressGpsMessengerExtension extends Extension
 {


### PR DESCRIPTION
Replace deprecated `Symfony\Component\HttpKernel\DependencyInjection\Extension` with `Symfony\Component\DependencyInjection\Extension\Extension`

Fixes #34