### PR TITLE
fix: deserialize attributes of a received Pub/Sub message as `AttributesStamp`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,15 +31,17 @@
         "google/cloud-pubsub": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "vimeo/psalm": "^6.0",
-        "symfony/yaml": "^5.4|^6.0|^7.0",
-        "symplify/easy-coding-standard": "^11.1",
         "phpstan/phpstan": "^2.1",
-        "phpstan/phpstan-symfony": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0"
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0",
+        "phpunit/phpunit": "^9.5",
+        "symfony/property-access": "^5.4|^6.0|^7.0",
+        "symfony/serializer": "^5.4|^6.0|^7.0",
+        "symfony/yaml": "^5.4|^6.0|^7.0",
+        "symplify/easy-coding-standard": "^11.1",
+        "vimeo/psalm": "^6.0"
     },
     "autoload": {
         "psr-4": { "PetitPress\\GpsMessengerBundle\\": "src" }

--- a/src/Transport/GpsConfigurationResolver.php
+++ b/src/Transport/GpsConfigurationResolver.php
@@ -138,31 +138,31 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
      */
     private function getMergedOptions(string $dsn, array $options): array
     {
-        $dnsOptions = [];
-        $parsedDnsOptions = parse_url($dsn);
+        $dsnOptions = [];
+        $parsedDsnOptions = parse_url($dsn);
 
-        $dsnQueryOptions = $parsedDnsOptions['query'] ?? null;
+        $dsnQueryOptions = $parsedDsnOptions['query'] ?? null;
         if ($dsnQueryOptions !== null && $dsnQueryOptions !== '') {
-            parse_str($dsnQueryOptions, $dnsOptions);
+            parse_str($dsnQueryOptions, $dsnOptions);
         }
 
-        $dnsPathOption = $parsedDnsOptions['path'] ?? null;
-        if ($dnsPathOption !== null && $dnsPathOption !== '') {
-            if (! isset($dnsOptions['topic']) || ! is_array($dnsOptions['topic'])) {
-                $dnsOptions['topic'] = [];
+        $dsnPathOption = $parsedDsnOptions['path'] ?? null;
+        if ($dsnPathOption !== null && $dsnPathOption !== '') {
+            if (! isset($dsnOptions['topic']) || ! is_array($dsnOptions['topic'])) {
+                $dsnOptions['topic'] = [];
             }
-            $dnsOptions['topic']['name'] = substr($dnsPathOption, 1);
+            $dsnOptions['topic']['name'] = substr($dsnPathOption, 1);
         }
 
-        if (isset($dnsOptions['topic']['createIfNotExist'])) {
-            $dnsOptions['topic']['createIfNotExist'] = $this->toBool($dnsOptions['topic']['createIfNotExist'], true);
+        if (isset($dsnOptions['topic']['createIfNotExist']) && is_string($dsnOptions['topic']['createIfNotExist'])) {
+            $dsnOptions['topic']['createIfNotExist'] = $this->toBool($dsnOptions['topic']['createIfNotExist'], true);
         }
 
-        if (isset($dnsOptions['subscription']['createIfNotExist'])) {
-            $dnsOptions['subscription']['createIfNotExist'] = $this->toBool($dnsOptions['subscription']['createIfNotExist'], true);
+        if (isset($dsnOptions['subscription']['createIfNotExist']) && is_string($dsnOptions['subscription']['createIfNotExist'])) {
+            $dsnOptions['subscription']['createIfNotExist'] = $this->toBool($dsnOptions['subscription']['createIfNotExist'], true);
         }
 
-        return array_merge($dnsOptions, $options);
+        return array_merge($dsnOptions, $options);
     }
 
     private function toBool(string $value, bool $default): bool

--- a/src/Transport/GpsReceiver.php
+++ b/src/Transport/GpsReceiver.php
@@ -8,6 +8,7 @@ use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\PubSubClient;
 use JsonException;
 use LogicException;
+use PetitPress\GpsMessengerBundle\Transport\Stamp\AttributesStamp;
 use PetitPress\GpsMessengerBundle\Transport\Stamp\GpsReceivedStamp;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -117,6 +118,13 @@ final class GpsReceiver implements ReceiverInterface
             throw new MessageDecodingFailedException($exception->getMessage(), 0, $exception);
         }
 
-        return $this->serializer->decode($rawData)->with(new GpsReceivedStamp($message));
+        $envelope = $this->serializer->decode($rawData)->with(new GpsReceivedStamp($message));
+
+        $attributes = $message->attributes();
+        if ($attributes !== []) {
+            $envelope = $envelope->with(new AttributesStamp($attributes));
+        }
+
+        return $envelope;
     }
 }

--- a/src/Transport/GpsReceiver.php
+++ b/src/Transport/GpsReceiver.php
@@ -112,7 +112,7 @@ final class GpsReceiver implements ReceiverInterface
     private function createEnvelopeFromPubSubMessage(Message $message): Envelope
     {
         try {
-            /** @var array<string, mixed> $rawData */
+            /** @var array{body: string, headers?: array<string, string>} $rawData */
             $rawData = json_decode($message->data(), true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $exception) {
             throw new MessageDecodingFailedException($exception->getMessage(), 0, $exception);

--- a/tests/Stub/DTO/StubDto.php
+++ b/tests/Stub/DTO/StubDto.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetitPress\GpsMessengerBundle\Tests\Stub\DTO;
+
+final readonly class StubDto
+{
+    public function __construct(
+        public string $property1,
+        public string $property2,
+    ) {
+    }
+}

--- a/tests/Transport/GpsReceiverTest.php
+++ b/tests/Transport/GpsReceiverTest.php
@@ -7,12 +7,16 @@ namespace PetitPress\GpsMessengerBundle\Tests\Transport;
 use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\Subscription;
+use PetitPress\GpsMessengerBundle\Tests\Stub\DTO\StubDto;
 use PetitPress\GpsMessengerBundle\Transport\GpsConfigurationInterface;
 use PetitPress\GpsMessengerBundle\Transport\GpsReceiver;
+use PetitPress\GpsMessengerBundle\Transport\Stamp\AttributesStamp;
 use PetitPress\GpsMessengerBundle\Transport\Stamp\GpsReceivedStamp;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
@@ -38,6 +42,8 @@ class GpsReceiverTest extends TestCase
      */
     private MockObject $subscriptionMock;
 
+    private SerializerInterface $serializer;
+
     private GpsReceiver $gpsReceiver;
 
     protected function setUp(): void
@@ -45,14 +51,49 @@ class GpsReceiverTest extends TestCase
         $this->gpsConfigurationMock = $this->createMock(GpsConfigurationInterface::class);
         $this->pubSubClientMock = $this->createMock(PubSubClient::class);
         $this->subscriptionMock = $this->createMock(Subscription::class);
-        /** @var SerializerInterface&MockObject $serializerMock */
-        $serializerMock = $this->createMock(SerializerInterface::class);
+        $this->serializer = Serializer::create();
 
         $this->gpsReceiver = new GpsReceiver(
             $this->pubSubClientMock,
             $this->gpsConfigurationMock,
-            $serializerMock,
+            $this->serializer,
         );
+    }
+
+    public function testItGets(): void
+    {
+        $body = new StubDto('property-value-1', 'property-value-2');
+        $headers = ['type' => $body::class];
+        $attributes = ['attr-1' => 'val-1', 'attr-2' => 'val-2'];
+        $gpsMessage = new Message(
+            [
+                'data' => json_encode(['headers' => $headers, 'body' => json_encode($body)]),
+                'attributes' => $attributes,
+            ]
+        );
+
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getSubscriptionName')
+            ->willReturn(self::SUBSCRIPTION_NAME);
+
+        $this->subscriptionMock
+            ->expects(static::once())
+            ->method('pull')
+            ->willReturn([$gpsMessage]);
+
+        $this->pubSubClientMock
+            ->expects(static::once())
+            ->method('subscription')
+            ->with(self::SUBSCRIPTION_NAME)
+            ->willReturn($this->subscriptionMock);
+
+        /** @var Envelope[] $envelopes */
+        $envelopes = iterator_to_array($this->gpsReceiver->get());
+        static::assertCount(1, $envelopes);
+        $envelope = $envelopes[0];
+        static::assertEquals($body, $envelope->getMessage());
+        static::assertSame($attributes, $envelope->last(AttributesStamp::class)?->getAttributes());
     }
 
     public function testItRejects(): void


### PR DESCRIPTION
3.x variant of #71.