### PR TITLE
feat: add `encoding_strategy` option (wrapped / hybrid / flat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,30 @@ Configure the cache service where authentication tokens are stored. The default 
 
 petit_press_gps_messenger:
     auth_cache: 'cache.app'
+    encoding_strategy: 'wrapped' # default; deprecated, see below
 ```
+
+#### Encoding strategy
+
+The `encoding_strategy` option controls how Symfony Messenger envelopes are mapped to Pub/Sub messages:
+
+| Value | Behavior |
+| ----- | -------- |
+| `wrapped` *(default, deprecated)* | Legacy format: the Symfony serializer output (`{body, headers}`) is JSON-encoded into the Pub/Sub message data; serializer headers are not exposed as Pub/Sub attributes. Will be removed in 5.0. |
+| `hybrid` | **Sender** publishes flat (see below). **Receiver** can decode both legacy `wrapped` payloads and new `flat` payloads. Use this on receivers during migration. |
+| `flat` | New format: the serializer body is published as the Pub/Sub message `data`, and serializer headers are published as Pub/Sub `attributes`. Recommended for new projects. |
+
+`hybrid`/`flat` senders mark each published message with a reserved Pub/Sub attribute (`ppgps-encoding-version`); the `hybrid` receiver routes per-message based on that attribute. Messages published by older bundle versions (no attribute) are decoded as `wrapped` — including ones already in the topic when the upgrade is deployed. The reserved attribute key cannot be overridden via `AttributesStamp`.
+
+Recommended migration path for existing deployments:
+
+1. Deploy receivers with `encoding_strategy: 'hybrid'`. They will continue decoding legacy `wrapped` messages while also accepting new `flat` messages.
+2. Once all receivers are on `hybrid`, switch publishers to `'hybrid'` (or `'flat'`). New messages will be published in the flat format and tagged with the encoding attribute.
+3. After the legacy backlog has drained, switch everything to `'flat'`.
+
+For new projects, set `encoding_strategy: 'flat'` from the start.
+
+When using `hybrid` or `flat`, an `AttributesStamp` is merged with the serializer headers (stamp values take precedence on key collisions, except for the reserved encoding attribute).
 
 ### Step 5: Use available stamps if needed
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PetitPress\GpsMessengerBundle\DependencyInjection;
 
+use PetitPress\GpsMessengerBundle\Transport\EncodingStrategy;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -20,6 +21,11 @@ final class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                     ->defaultValue('cache.app')
                     ->info('A cache for storing access tokens.')
+                ->end()
+                ->enumNode('encoding_strategy')
+                    ->values(array_map(static fn ($strategy) => $strategy->value, EncodingStrategy::cases()))
+                    ->defaultValue(EncodingStrategy::Wrapped->value)
+                    ->info('Encoding strategy: "wrapped" (legacy, message is wrapped in another json), "hybrid" (message is encoded as flat, wrapped messages supported during decoding, best for migration; the receiver decides per-message based on the reserved "ppgps-encoding-version" Pub/Sub attribute set by flat/hybrid senders) or "flat" (new, simplified json).')
                 ->end()
                 ->enumNode('forced_transport')
                     ->values(['grpc', 'rest'])

--- a/src/DependencyInjection/PetitPressGpsMessengerExtension.php
+++ b/src/DependencyInjection/PetitPressGpsMessengerExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PetitPress\GpsMessengerBundle\DependencyInjection;
 
+use PetitPress\GpsMessengerBundle\Transport\EncodingStrategy;
 use PetitPress\GpsMessengerBundle\Transport\GpsTransportFactory;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -30,6 +31,15 @@ final class PetitPressGpsMessengerExtension extends Extension
         }
         if (isset($config['forced_transport'])) {
             $gpsTransportFactoryDefinition->replaceArgument(2, $config['forced_transport']);
+        }
+        $encodingStrategy = EncodingStrategy::from($config['encoding_strategy']);
+        $gpsTransportFactoryDefinition->replaceArgument(3, $encodingStrategy);
+        if (EncodingStrategy::Wrapped === $encodingStrategy) {
+            trigger_deprecation(
+                'petitpress/gps-messenger-bundle',
+                '4.1',
+                'The "wrapped" encoding_strategy is deprecated and will be removed in 5.0. Use "hybrid" if your project is already in production or "flat" for new projects. In 5.0 only the "flat" encoding strategy will be supported and there will be no configuration option to change it.'
+            );
         }
     }
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PetitPress\GpsMessengerBundle\Transport\EncodingStrategy;
 use PetitPress\GpsMessengerBundle\Transport\GpsConfigurationResolver;
 use PetitPress\GpsMessengerBundle\Transport\GpsConfigurationResolverInterface;
 use PetitPress\GpsMessengerBundle\Transport\GpsTransportFactory;
@@ -14,7 +15,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             new ReferenceConfigurator(GpsConfigurationResolverInterface::class),
             null,
-            null
+            null,
+            EncodingStrategy::Wrapped,
         ])
         ->tag('messenger.transport_factory')
 

--- a/src/Transport/EncodingStrategy.php
+++ b/src/Transport/EncodingStrategy.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetitPress\GpsMessengerBundle\Transport;
+
+enum EncodingStrategy: string
+{
+    /**
+     * Pub/Sub attribute key used to mark messages encoded with the flat strategy.
+     * Reserved name: must not be set via AttributesStamp by users.
+     */
+    public const ENCODING_ATTRIBUTE = 'ppgps-encoding-version';
+
+    /**
+     * Current value of the encoding attribute. Bumping this value lets the receiver
+     * detect future encoding changes and is the only way the receiver routes a
+     * message to the flat decoder.
+     */
+    public const ENCODING_VERSION = '2';
+
+    case Wrapped = 'wrapped';
+    case Hybrid = 'hybrid';
+    case Flat = 'flat';
+}

--- a/src/Transport/GpsConfigurationResolver.php
+++ b/src/Transport/GpsConfigurationResolver.php
@@ -161,11 +161,11 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             $dnsOptions['use_messenger_retry'] = $this->toBool($dnsOptions['use_messenger_retry'], false);
         }
 
-        if (isset($dnsOptions['topic']['createIfNotExist'])) {
+        if (isset($dnsOptions['topic']['createIfNotExist']) && is_string($dnsOptions['topic']['createIfNotExist'])) {
             $dnsOptions['topic']['createIfNotExist'] = $this->toBool($dnsOptions['topic']['createIfNotExist'], true);
         }
 
-        if (isset($dnsOptions['subscription']['createIfNotExist'])) {
+        if (isset($dnsOptions['subscription']['createIfNotExist']) && is_string($dnsOptions['subscription']['createIfNotExist'])) {
             $dnsOptions['subscription']['createIfNotExist'] = $this->toBool($dnsOptions['subscription']['createIfNotExist'], true);
         }
 

--- a/src/Transport/GpsReceiver.php
+++ b/src/Transport/GpsReceiver.php
@@ -26,7 +26,8 @@ final class GpsReceiver implements KeepaliveReceiverInterface
     public function __construct(
         private PubSubClient $pubSubClient,
         private GpsConfigurationInterface $gpsConfiguration,
-        private SerializerInterface $serializer
+        private SerializerInterface $serializer,
+        private EncodingStrategy $encodingStrategy = EncodingStrategy::Wrapped,
     ) {
     }
 
@@ -105,18 +106,43 @@ final class GpsReceiver implements KeepaliveReceiverInterface
     /**
      * Creates Symfony Envelope from Google Pub/Sub Message.
      * It adds stamp with received native Google Pub/Sub message.
+     *
+     * In Hybrid mode the encoding format is detected per-message via the reserved
+     * EncodingStrategy::ENCODING_ATTRIBUTE Pub/Sub attribute set by Flat/Hybrid senders.
+     * Messages without it (e.g. published by older bundle versions still using the
+     * Wrapped strategy) fall through to wrapped decoding, which is the safe default.
      */
     private function createEnvelopeFromPubSubMessage(Message $message): Envelope
     {
+        if (EncodingStrategy::Flat === $this->encodingStrategy || $this->isFlatEncoded($message)) {
+            $attributes = $message->attributes();
+            unset($attributes[EncodingStrategy::ENCODING_ATTRIBUTE]);
+
+            $envelope = $this->serializer->decode([
+                'body' => $message->data(),
+                'headers' => $attributes,
+            ]);
+
+            return $envelope->with(new GpsReceivedStamp($message));
+        }
+
         try {
-            /** @var array<string, mixed> $rawData */
+            /** @var array{body: string, headers?: array<string, string>} $rawData */
             $rawData = json_decode($message->data(), true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $exception) {
             throw new MessageDecodingFailedException($exception->getMessage(), 0, $exception);
         }
 
-        /** @var array{body: string, headers?: array<string, string>} $rawData */
         return $this->serializer->decode($rawData)->with(new GpsReceivedStamp($message));
+    }
+
+    private function isFlatEncoded(Message $message): bool
+    {
+        if (EncodingStrategy::Hybrid !== $this->encodingStrategy) {
+            return false;
+        }
+
+        return $message->attribute(EncodingStrategy::ENCODING_ATTRIBUTE) === EncodingStrategy::ENCODING_VERSION;
     }
 
     public function keepalive(Envelope $envelope, ?int $seconds = null): void

--- a/src/Transport/GpsSender.php
+++ b/src/Transport/GpsSender.php
@@ -20,18 +20,12 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  */
 final class GpsSender implements SenderInterface
 {
-    private PubSubClient $pubSubClient;
-    private GpsConfigurationInterface $gpsConfiguration;
-    private SerializerInterface $serializer;
-
     public function __construct(
-        PubSubClient $pubSubClient,
-        GpsConfigurationInterface $gpsConfiguration,
-        SerializerInterface $serializer
+        private PubSubClient $pubSubClient,
+        private GpsConfigurationInterface $gpsConfiguration,
+        private SerializerInterface $serializer,
+        private EncodingStrategy $encodingStrategy = EncodingStrategy::Wrapped,
     ) {
-        $this->pubSubClient = $pubSubClient;
-        $this->gpsConfiguration = $gpsConfiguration;
-        $this->serializer = $serializer;
     }
 
     /**
@@ -39,14 +33,8 @@ final class GpsSender implements SenderInterface
      */
     public function send(Envelope $envelope): Envelope
     {
+        /** @var array{body: string, headers?: array<string, string>} $encodedMessage */
         $encodedMessage = $this->serializer->encode($envelope);
-
-        $messageBuilder = new MessageBuilder();
-        try {
-            $messageBuilder = $messageBuilder->setData(json_encode($encodedMessage, JSON_THROW_ON_ERROR));
-        } catch (\JsonException $exception) {
-            throw new TransportException($exception->getMessage(), 0, $exception);
-        }
 
         if (! $this->gpsConfiguration->shouldUseMessengerRetry()) {
             $redeliveryStamp = $envelope->last(RedeliveryStamp::class);
@@ -56,15 +44,18 @@ final class GpsSender implements SenderInterface
             }
         }
 
+        $messageBuilder = $this->setMessage(new MessageBuilder(), $encodedMessage);
+
         $orderingKeyStamp = $envelope->last(OrderingKeyStamp::class);
         if ($orderingKeyStamp instanceof OrderingKeyStamp) {
             $messageBuilder = $messageBuilder->setOrderingKey($orderingKeyStamp->getOrderingKey());
         }
 
         $attributesStamp = $envelope->last(AttributesStamp::class);
-        if ($attributesStamp instanceof AttributesStamp) {
-            $messageBuilder = $messageBuilder->setAttributes($attributesStamp->getAttributes());
-        }
+        $stampAttributes = $attributesStamp instanceof AttributesStamp ? $attributesStamp->getAttributes() : [];
+        $messageBuilder = $messageBuilder->setAttributes(
+            $this->buildAttributes($encodedMessage['headers'] ?? [], $stampAttributes)
+        );
 
         $senderOptionsStamp = $envelope->last(GpsSenderOptionsStamp::class);
         $options = [];
@@ -77,5 +68,45 @@ final class GpsSender implements SenderInterface
         ;
 
         return $envelope;
+    }
+
+    /**
+     * @param array{body: string, headers?: array<string, string>} $encodedMessage
+     */
+    private function setMessage(MessageBuilder $messageBuilder, array $encodedMessage): MessageBuilder
+    {
+        if (EncodingStrategy::Flat === $this->encodingStrategy || EncodingStrategy::Hybrid === $this->encodingStrategy) {
+            return $messageBuilder->setData($encodedMessage['body']);
+        }
+
+        try {
+            return $messageBuilder->setData(json_encode($encodedMessage, JSON_THROW_ON_ERROR));
+        } catch (\JsonException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+    }
+
+    /**
+     * Computes the final Pub/Sub attribute set:
+     *   - Wrapped: only AttributesStamp values are exposed (headers are inside the JSON body).
+     *   - Flat/Hybrid: serializer headers + AttributesStamp values (stamp wins on collision),
+     *     plus the reserved encoding-version attribute appended last so AttributesStamp can never override it.
+     *
+     * @param array<string, string> $headers
+     * @param array<string, string> $stampAttributes
+     *
+     * @return array<string, string>
+     */
+    private function buildAttributes(array $headers, array $stampAttributes): array
+    {
+        if (EncodingStrategy::Wrapped === $this->encodingStrategy) {
+            return $stampAttributes;
+        }
+
+        return array_merge(
+            $headers,
+            $stampAttributes,
+            [EncodingStrategy::ENCODING_ATTRIBUTE => EncodingStrategy::ENCODING_VERSION],
+        );
     }
 }

--- a/src/Transport/GpsTransport.php
+++ b/src/Transport/GpsTransport.php
@@ -23,7 +23,8 @@ final class GpsTransport implements TransportInterface, KeepaliveReceiverInterfa
     public function __construct(
         private PubSubClient $pubSubClient,
         private GpsConfigurationInterface $gpsConfiguration,
-        private SerializerInterface $serializer
+        private SerializerInterface $serializer,
+        private EncodingStrategy $encodingStrategy = EncodingStrategy::Wrapped,
     ) {
     }
 
@@ -62,13 +63,23 @@ final class GpsTransport implements TransportInterface, KeepaliveReceiverInterfa
     public function getReceiver(): KeepaliveReceiverInterface
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
-        return $this->receiver ??= new GpsReceiver($this->pubSubClient, $this->gpsConfiguration, $this->serializer);
+        return $this->receiver ??= new GpsReceiver(
+            $this->pubSubClient,
+            $this->gpsConfiguration,
+            $this->serializer,
+            $this->encodingStrategy,
+        );
     }
 
     public function getSender(): SenderInterface
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
-        return $this->sender ??= new GpsSender($this->pubSubClient, $this->gpsConfiguration, $this->serializer);
+        return $this->sender ??= new GpsSender(
+            $this->pubSubClient,
+            $this->gpsConfiguration,
+            $this->serializer,
+            $this->encodingStrategy,
+        );
     }
 
     public function setup(): void

--- a/src/Transport/GpsTransportFactory.php
+++ b/src/Transport/GpsTransportFactory.php
@@ -16,18 +16,12 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  */
 final class GpsTransportFactory implements TransportFactoryInterface
 {
-    private GpsConfigurationResolverInterface $gpsConfigurationResolver;
-    private ?CacheItemPoolInterface $cache;
-    private ?string $forcedTransport;
-
     public function __construct(
-        GpsConfigurationResolverInterface $gpsConfigurationResolver,
-        ?CacheItemPoolInterface $cache,
-        ?string $forcedTransport
+        private GpsConfigurationResolverInterface $gpsConfigurationResolver,
+        private ?CacheItemPoolInterface $cache,
+        private ?string $forcedTransport,
+        private EncodingStrategy $encodingStrategy = EncodingStrategy::Wrapped,
     ) {
-        $this->gpsConfigurationResolver = $gpsConfigurationResolver;
-        $this->cache = $cache;
-        $this->forcedTransport = $forcedTransport;
     }
 
     /**
@@ -53,7 +47,8 @@ final class GpsTransportFactory implements TransportFactoryInterface
         return new GpsTransport(
             new PubSubClient($clientConfig),
             $options,
-            $serializer
+            $serializer,
+            $this->encodingStrategy,
         );
     }
 

--- a/tests/DependencyInjection/PetitPressGpsMessengerExtensionTest.php
+++ b/tests/DependencyInjection/PetitPressGpsMessengerExtensionTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace PetitPress\GpsMessengerBundle\Tests\DependencyInjection;
 
 use PetitPress\GpsMessengerBundle\DependencyInjection\PetitPressGpsMessengerExtension;
+use PetitPress\GpsMessengerBundle\Transport\EncodingStrategy;
 use PetitPress\GpsMessengerBundle\Transport\GpsTransportFactory;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -13,6 +15,7 @@ use Symfony\Component\Yaml\Parser;
 
 class PetitPressGpsMessengerExtensionTest extends TestCase
 {
+    #[IgnoreDeprecations]
     public function testSimpleConfiguration(): void
     {
         $configuration = new ContainerBuilder();
@@ -25,15 +28,16 @@ class PetitPressGpsMessengerExtensionTest extends TestCase
         $cacheArgument = $gpsTransportFactoryDefinition->getArgument(1);
         static::assertInstanceOf(Reference::class, $cacheArgument);
         static::assertEquals('cache.app', (string) $cacheArgument);
+        static::assertEquals(EncodingStrategy::Wrapped, $gpsTransportFactoryDefinition->getArgument(3));
     }
 
     /**
-     * @return mixed
+     * @return array<string, mixed>
      */
-    private function getSimpleConfig()
+    private function getSimpleConfig(): array
     {
-        // use all defaults
-        return (new Parser())->parse('');
+        // use all defaults — empty YAML parses to null, so return [] explicitly
+        return [];
     }
 
     public function testFullConfiguration(): void
@@ -48,6 +52,7 @@ class PetitPressGpsMessengerExtensionTest extends TestCase
         $cacheArgument = $gpsTransportFactoryDefinition->getArgument(1);
         static::assertInstanceOf(Reference::class, $cacheArgument);
         static::assertEquals('foo', (string) $cacheArgument);
+        static::assertEquals(EncodingStrategy::Flat, $gpsTransportFactoryDefinition->getArgument(3));
     }
 
     /**
@@ -57,6 +62,7 @@ class PetitPressGpsMessengerExtensionTest extends TestCase
     {
         $yaml = <<<EOF
 auth_cache: 'foo'
+encoding_strategy: 'flat'
 EOF;
         /** @var array<string, mixed> */
         return (new Parser())->parse($yaml);
@@ -76,14 +82,14 @@ EOF;
     }
 
     /**
-     * @return mixed
+     * @return array<string, mixed>
      */
-    private function getDisabledCacheConfig()
+    private function getDisabledCacheConfig(): array
     {
         $yaml = <<<EOF
 auth_cache: false
 EOF;
-
+        /** @var array<string, mixed> */
         return (new Parser())->parse($yaml);
     }
 }

--- a/tests/Transport/GpsReceiverTest.php
+++ b/tests/Transport/GpsReceiverTest.php
@@ -8,12 +8,14 @@ use Exception;
 use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\Subscription;
+use PetitPress\GpsMessengerBundle\Transport\EncodingStrategy;
 use PetitPress\GpsMessengerBundle\Transport\GpsConfigurationInterface;
 use PetitPress\GpsMessengerBundle\Transport\GpsReceiver;
 use PetitPress\GpsMessengerBundle\Transport\Stamp\GpsReceivedStamp;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
@@ -42,18 +44,22 @@ class GpsReceiverTest extends TestCase
 
     private GpsReceiver $gpsReceiver;
 
+    /**
+     * @var SerializerInterface&MockObject
+     */
+    private MockObject $serializerMock;
+
     protected function setUp(): void
     {
         $this->gpsConfigurationMock = $this->createMock(GpsConfigurationInterface::class);
         $this->pubSubClientMock = $this->createMock(PubSubClient::class);
         $this->subscriptionMock = $this->createMock(Subscription::class);
-        /** @var SerializerInterface&MockObject $serializerMock */
-        $serializerMock = $this->createMock(SerializerInterface::class);
+        $this->serializerMock = $this->createMock(SerializerInterface::class);
 
         $this->gpsReceiver = new GpsReceiver(
             $this->pubSubClientMock,
             $this->gpsConfigurationMock,
-            $serializerMock,
+            $this->serializerMock,
         );
     }
 
@@ -194,6 +200,188 @@ class GpsReceiverTest extends TestCase
         return [
             [null, 5],
             [15, 15]
+        ];
+    }
+
+    #[DataProvider('wrappedEncodingStrategies')]
+    public function testGetWrapped(EncodingStrategy $encodingStrategy): void
+    {
+        $gpsReceiver = new GpsReceiver(
+            $this->pubSubClientMock,
+            $this->gpsConfigurationMock,
+            $this->serializerMock,
+            $encodingStrategy,
+        );
+
+        $gpsMessage = new Message(['data' => '{"body":"foo"}']);
+
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getSubscriptionName')
+            ->willReturn(self::SUBSCRIPTION_NAME)
+        ;
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getSubscriptionPullOptions')
+            ->willReturn([])
+        ;
+        $this->pubSubClientMock
+            ->expects(static::once())
+            ->method('subscription')
+            ->with(self::SUBSCRIPTION_NAME)
+            ->willReturn($this->subscriptionMock)
+        ;
+        $this->subscriptionMock
+            ->expects(static::once())
+            ->method('pull')
+            ->with([])
+            ->willReturn([$gpsMessage])
+        ;
+
+        $gpsEnvelope = new Envelope($gpsMessage);
+        $this->serializerMock
+            ->expects(static::once())
+            ->method('decode')
+            ->with(['body' => 'foo'])
+            ->willReturn($gpsEnvelope)
+        ;
+
+        $envelopes = $gpsReceiver->get();
+        $count = 0;
+        foreach ($envelopes as $envelope) {
+            self::assertEquals($gpsEnvelope->with(new GpsReceivedStamp($gpsMessage)), $envelope);
+            $count++;
+        }
+        self::assertSame(1, $count);
+    }
+
+    #[DataProvider('flatEncodingStrategies')]
+    public function testGetFlat(EncodingStrategy $encodingStrategy): void
+    {
+        $gpsReceiver = new GpsReceiver(
+            $this->pubSubClientMock,
+            $this->gpsConfigurationMock,
+            $this->serializerMock,
+            $encodingStrategy,
+        );
+
+        $gpsMessage = new Message([
+            'data' => '{"foo":"bar"}',
+            'attributes' => [
+                'type' => 'App\\Message',
+                EncodingStrategy::ENCODING_ATTRIBUTE => EncodingStrategy::ENCODING_VERSION,
+            ],
+        ]);
+
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getSubscriptionName')
+            ->willReturn(self::SUBSCRIPTION_NAME)
+        ;
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getSubscriptionPullOptions')
+            ->willReturn([])
+        ;
+        $this->pubSubClientMock
+            ->expects(static::once())
+            ->method('subscription')
+            ->with(self::SUBSCRIPTION_NAME)
+            ->willReturn($this->subscriptionMock)
+        ;
+        $this->subscriptionMock
+            ->expects(static::once())
+            ->method('pull')
+            ->with([])
+            ->willReturn([$gpsMessage])
+        ;
+
+        $gpsEnvelope = new Envelope($gpsMessage);
+        $this->serializerMock
+            ->expects(static::once())
+            ->method('decode')
+            ->with(['body' => '{"foo":"bar"}', 'headers' => ['type' => 'App\\Message']])
+            ->willReturn($gpsEnvelope)
+        ;
+
+        $envelopes = $gpsReceiver->get();
+        $count = 0;
+        foreach ($envelopes as $envelope) {
+            self::assertEquals($gpsEnvelope->with(new GpsReceivedStamp($gpsMessage)), $envelope);
+            $count++;
+        }
+        self::assertSame(1, $count);
+    }
+
+    public function testHybridFallsBackToWrappedWhenEncodingAttributeMissing(): void
+    {
+        $gpsReceiver = new GpsReceiver(
+            $this->pubSubClientMock,
+            $this->gpsConfigurationMock,
+            $this->serializerMock,
+            EncodingStrategy::Hybrid,
+        );
+
+        // Simulates a message published by an older bundle version (Wrapped sender):
+        // the body has the wrapped shape and no encoding-version attribute is present.
+        $gpsMessage = new Message(['data' => '{"body":"legacy"}']);
+
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getSubscriptionName')
+            ->willReturn(self::SUBSCRIPTION_NAME)
+        ;
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getSubscriptionPullOptions')
+            ->willReturn([])
+        ;
+        $this->pubSubClientMock
+            ->expects(static::once())
+            ->method('subscription')
+            ->with(self::SUBSCRIPTION_NAME)
+            ->willReturn($this->subscriptionMock)
+        ;
+        $this->subscriptionMock
+            ->expects(static::once())
+            ->method('pull')
+            ->with([])
+            ->willReturn([$gpsMessage])
+        ;
+
+        $gpsEnvelope = new Envelope($gpsMessage);
+        $this->serializerMock
+            ->expects(static::once())
+            ->method('decode')
+            ->with(['body' => 'legacy'])
+            ->willReturn($gpsEnvelope)
+        ;
+
+        $envelopes = $gpsReceiver->get();
+        foreach ($envelopes as $envelope) {
+            self::assertEquals($gpsEnvelope->with(new GpsReceivedStamp($gpsMessage)), $envelope);
+        }
+    }
+
+    /**
+     * @return list<list<EncodingStrategy>>
+     */
+    public static function wrappedEncodingStrategies(): array
+    {
+        return [
+            [EncodingStrategy::Wrapped],
+            [EncodingStrategy::Hybrid],
+        ];
+    }
+
+    /**
+     * @return list<list<EncodingStrategy>>
+     */
+    public static function flatEncodingStrategies(): array
+    {
+        return [
+            [EncodingStrategy::Flat],
+            [EncodingStrategy::Hybrid],
         ];
     }
 }

--- a/tests/Transport/GpsSenderTest.php
+++ b/tests/Transport/GpsSenderTest.php
@@ -7,11 +7,13 @@ namespace PetitPress\GpsMessengerBundle\Tests\Transport;
 use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\Topic;
+use PetitPress\GpsMessengerBundle\Transport\EncodingStrategy;
 use PetitPress\GpsMessengerBundle\Transport\GpsConfigurationInterface;
 use PetitPress\GpsMessengerBundle\Transport\GpsSender;
 use PetitPress\GpsMessengerBundle\Transport\Stamp\AttributesStamp;
 use PetitPress\GpsMessengerBundle\Transport\Stamp\GpsSenderOptionsStamp;
 use PetitPress\GpsMessengerBundle\Transport\Stamp\OrderingKeyStamp;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
@@ -261,5 +263,155 @@ class GpsSenderTest extends TestCase
             ->willReturn($this->topicMock);
 
         self::assertSame($envelope, $this->gpsSender->send($envelope));
+    }
+
+    #[DataProvider('flatEncodingStrategies')]
+    public function testItPublishesFlatOrHybrid(EncodingStrategy $encodingStrategy): void
+    {
+        $gpsSender = new GpsSender(
+            $this->pubSubClientMock,
+            $this->gpsConfigurationMock,
+            $this->serializerMock,
+            $encodingStrategy,
+        );
+
+        $envelope = EnvelopeFactory::create();
+        $envelopeArray = ['body' => '{}'];
+
+        $this->serializerMock
+            ->expects(static::once())
+            ->method('encode')
+            ->with($envelope)
+            ->willReturn($envelopeArray)
+        ;
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getTopicName')
+            ->willReturn(self::TOPIC_NAME)
+        ;
+        $this->topicMock
+            ->expects(static::once())
+            ->method('publish')
+            ->with(new Message([
+                'data' => '{}',
+                'attributes' => [
+                    EncodingStrategy::ENCODING_ATTRIBUTE => EncodingStrategy::ENCODING_VERSION,
+                ],
+            ]))
+        ;
+        $this->pubSubClientMock
+            ->expects(static::once())
+            ->method('topic')
+            ->with(self::TOPIC_NAME)
+            ->willReturn($this->topicMock)
+        ;
+
+        self::assertSame($envelope, $gpsSender->send($envelope));
+    }
+
+    #[DataProvider('flatEncodingStrategies')]
+    public function testFlatOrHybridMergesSerializerHeadersWithAttributesStamp(EncodingStrategy $encodingStrategy): void
+    {
+        $gpsSender = new GpsSender(
+            $this->pubSubClientMock,
+            $this->gpsConfigurationMock,
+            $this->serializerMock,
+            $encodingStrategy,
+        );
+
+        $envelope = EnvelopeFactory::create(new AttributesStamp(['stamp' => 'value', 'type' => 'overridden']));
+        $envelopeArray = ['body' => '{}', 'headers' => ['type' => 'App\\Message', 'header' => 'value']];
+
+        $this->serializerMock
+            ->expects(static::once())
+            ->method('encode')
+            ->with($envelope)
+            ->willReturn($envelopeArray)
+        ;
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getTopicName')
+            ->willReturn(self::TOPIC_NAME)
+        ;
+        $this->topicMock
+            ->expects(static::once())
+            ->method('publish')
+            ->with(new Message([
+                'data' => '{}',
+                'attributes' => [
+                    'type' => 'overridden',
+                    'header' => 'value',
+                    'stamp' => 'value',
+                    EncodingStrategy::ENCODING_ATTRIBUTE => EncodingStrategy::ENCODING_VERSION,
+                ],
+            ]))
+        ;
+        $this->pubSubClientMock
+            ->expects(static::once())
+            ->method('topic')
+            ->with(self::TOPIC_NAME)
+            ->willReturn($this->topicMock)
+        ;
+
+        self::assertSame($envelope, $gpsSender->send($envelope));
+    }
+
+    #[DataProvider('flatEncodingStrategies')]
+    public function testEncodingAttributeCannotBeOverriddenByAttributesStamp(EncodingStrategy $encodingStrategy): void
+    {
+        $gpsSender = new GpsSender(
+            $this->pubSubClientMock,
+            $this->gpsConfigurationMock,
+            $this->serializerMock,
+            $encodingStrategy,
+        );
+
+        $envelope = EnvelopeFactory::create(new AttributesStamp([
+            EncodingStrategy::ENCODING_ATTRIBUTE => 'attacker',
+            'foo' => 'bar',
+        ]));
+        $envelopeArray = ['body' => '{}'];
+
+        $this->serializerMock
+            ->expects(static::once())
+            ->method('encode')
+            ->with($envelope)
+            ->willReturn($envelopeArray)
+        ;
+        $this->gpsConfigurationMock
+            ->expects(static::once())
+            ->method('getTopicName')
+            ->willReturn(self::TOPIC_NAME)
+        ;
+        $this->topicMock
+            ->expects(static::once())
+            ->method('publish')
+            ->with(new Message([
+                'data' => '{}',
+                'attributes' => [
+                    'foo' => 'bar',
+                    EncodingStrategy::ENCODING_ATTRIBUTE => EncodingStrategy::ENCODING_VERSION,
+                ],
+            ]))
+        ;
+        $this->pubSubClientMock
+            ->expects(static::once())
+            ->method('topic')
+            ->with(self::TOPIC_NAME)
+            ->willReturn($this->topicMock)
+        ;
+
+        self::assertSame($envelope, $gpsSender->send($envelope));
+    }
+
+    /**
+     * @return list<list<EncodingStrategy>>
+     */
+    public static function flatEncodingStrategies(): array
+    {
+        return [
+            [EncodingStrategy::Flat],
+            [EncodingStrategy::Hybrid],
+        ];
     }
 }


### PR DESCRIPTION
Introduces an opt-in encoding format for Pub/Sub messages that exposes serializer headers as native Pub/Sub attributes instead of nesting them inside a JSON wrapper.
  - `wrapped` (default, deprecated): legacy `{body, headers}` JSON in the message data; will be removed in 5.0.
  - `flat`: serializer body is published as `data`, serializer headers as attributes. Recommended for new projects.
  - `hybrid`: senders publish flat, receivers decode both formats. Use on receivers during migration.

Per-message format detection in `hybrid` mode uses a reserved Pub/Sub attribute (`ppgps-encoding-version`) set by flat/hybrid senders; messages without it (older bundle versions, including ones already in the topic at upgrade time) fall back to wrapped decoding. The reserved attribute key cannot be overridden via `AttributesStamp` — the sender appends it last.

In flat/hybrid mode an `AttributesStamp` is merged with the serializer headers (stamp wins on collision), preventing the stamp from silently dropping serializer headers.